### PR TITLE
https connection with wiremock

### DIFF
--- a/lib/service_mock/command_line_options.rb
+++ b/lib/service_mock/command_line_options.rb
@@ -51,11 +51,11 @@ module ServiceMock
     end
 
     def https_keystore_command
-      ["--https-keystore #{https_keystore}"]
+      ['--https-keystore', https_keystore]
     end
 
     def keystore_password_command
-      ["--keystore-password #{keystore_password}"]
+      ['--keystore-password', keystore_password]
     end
 
     def enable_browser_proxying_command

--- a/lib/service_mock/server.rb
+++ b/lib/service_mock/server.rb
@@ -43,7 +43,7 @@ module ServiceMock
   class Server
     include CommandLineOptions
 
-    attr_accessor :inherit_io, :wait_for_process, :remote_host, :classpath
+    attr_accessor :inherit_io, :wait_for_process, :remote_host, :classpath, :use_ssl
     attr_reader :wiremock_version, :working_directory, :process
     attr_accessor :proxy_addr, :proxy_port, :proxy_user, :proxy_pass
 
@@ -52,6 +52,7 @@ module ServiceMock
       @working_directory = working_directory
       self.inherit_io = false
       self.wait_for_process = false
+      self.use_ssl = false
     end
 
     #
@@ -215,10 +216,13 @@ module ServiceMock
 
     def http
       if using_proxy
-        return Net::HTTP.Proxy(proxy_addr, proxy_port,
+        http = Net::HTTP.Proxy(proxy_addr, proxy_port,
                         proxy_user, proxy_pass)
+      else
+        http = Net::HTTP.new(admin_host, admin_port)
       end
-      Net::HTTP.new(admin_host, admin_port)
+      http.use_ssl = use_ssl
+      http
     end
 
     def using_proxy

--- a/lib/service_mock/version.rb
+++ b/lib/service_mock/version.rb
@@ -1,3 +1,3 @@
 module ServiceMock
-  VERSION = "0.8"
+  VERSION = "0.9"
 end

--- a/spec/lib/command_line_options_spec.rb
+++ b/spec/lib/command_line_options_spec.rb
@@ -46,12 +46,12 @@ describe ServiceMock::CommandLineOptions do
 
   it 'provides a https_keystore option' do
     clo.https_keystore = '/path/to/keystore'
-    expect(clo.https_keystore_command).to eql ['--https-keystore /path/to/keystore']
+    expect(clo.https_keystore_command).to eql ['--https-keystore', '/path/to/keystore']
   end
 
   it 'provides a keystore_password option' do
     clo.keystore_password = 'passWord'
-    expect(clo.keystore_password_command).to eql ['--keystore-password passWord']
+    expect(clo.keystore_password_command).to eql ['--keystore-password', 'passWord']
   end
 
   it 'provides a enable_borwser_proxying option' do


### PR DESCRIPTION
EOFError: end of file reached when using service_mock to connect to a remote wiremock instance via https, this was solved by adding a use_ssl flag when the http object is being created.

When using https_keystore or keystore_password, there is an UnrecognizedOptionException. This is solved by making the keystore and the command separate indices in the array when the command is being created